### PR TITLE
Transition requirement from C++17 to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ CMAKE_MINIMUM_REQUIRED (VERSION 3.9.2)
 PROJECT (buildmode 
 		VERSION 1.0.0 
 		LANGUAGES CXX 
-		DESCRIPTION "A C++17 library to easily handle code paths for different build modes like Debug and Release.")
+		DESCRIPTION "A C++11 library to easily handle code paths for different build modes like Debug and Release.")
 
 
 
@@ -46,11 +46,11 @@ IF (BUILD_TESTING)
 	TARGET_LINK_LIBRARIES (isRelease buildmode ${COVERAGE_FLAG})
 	
 	IF (MSVC)
-		TARGET_COMPILE_OPTIONS (isDebug PRIVATE /std:c++17)
-		TARGET_COMPILE_OPTIONS (isRelease PRIVATE /std:c++17 /DNDEBUG)
+		TARGET_COMPILE_OPTIONS (isDebug PRIVATE /std:c++11)
+		TARGET_COMPILE_OPTIONS (isRelease PRIVATE /std:c++11 /DNDEBUG)
 	ELSE ()
-		TARGET_COMPILE_OPTIONS (isDebug PRIVATE -std=c++17 -g -Wall -Wextra -Werror -pedantic ${COVERAGE_FLAG})
-		TARGET_COMPILE_OPTIONS (isRelease PRIVATE -std=c++17 -DNDEBUG -O3 -Wall -Wextra -Werror -pedantic ${COVERAGE_FLAG})
+		TARGET_COMPILE_OPTIONS (isDebug PRIVATE -std=c++11 -g -Wall -Wextra -Werror -pedantic ${COVERAGE_FLAG})
+		TARGET_COMPILE_OPTIONS (isRelease PRIVATE -std=c++11 -DNDEBUG -O3 -Wall -Wextra -Werror -pedantic ${COVERAGE_FLAG})
 	ENDIF ()
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BuildMode 
 
-A C++17 library to easily handle code paths for Debug and Release at compile time.
+A C++11 library to easily handle code paths for Debug and Release at compile time.
 
 [![Travis CI](https://travis-ci.com/MuAlphaOmegaEpsilon/buildmode.svg?branch=master)](https://travis-ci.com/MuAlphaOmegaEpsilon/buildmode/) 
 [![codecov](https://codecov.io/gh/MuAlphaOmegaEpsilon/buildmode/branch/master/graph/badge.svg)](https://codecov.io/gh/MuAlphaOmegaEpsilon/buildmode) 
@@ -10,6 +10,21 @@ A C++17 library to easily handle code paths for Debug and Release at compile tim
 
 ## How to use
 ```cpp
+// C++11 version should be easily handled by basically every serious compiler 
+if (BuildMode::isRelease)
+{
+	// COMPILER SHOULD STRIP WHEN NOT IN RELEASE
+	...
+}
+
+if (BuildMode::isDebug)
+{
+	// COMPILER SHOULD STRIP WHEN NOT IN DEBUG
+	...
+}
+
+
+// C++17 version guarantees compile-time evaluation
 if constexpr (BuildMode::isRelease)
 {
 	// CODE STRIPPED WHEN NOT IN RELEASE

--- a/buildmode.hpp
+++ b/buildmode.hpp
@@ -1,5 +1,5 @@
 /**
- * @brief A C++17 library to easily handle code paths for Debug and Release at compile time. 
+ * @brief A C++11 library to easily handle code paths for Debug and Release at compile time. 
  * @file buildmode.hpp
  * @author Tommaso Bonvicini <tommasobonvicini@gmail.com> https://github.com/MuAlphaOmegaEpsilon/buildmode
  * @date 17-02-2019

--- a/tests/debug_mode.cpp
+++ b/tests/debug_mode.cpp
@@ -3,7 +3,7 @@
 
 int main ()
 {
-	if constexpr (BuildMode::isDebug && !BuildMode::isRelease)
+	if (BuildMode::isDebug && !BuildMode::isRelease)
 		return EXIT_SUCCESS;
 	return EXIT_FAILURE;
 }

--- a/tests/release_mode.cpp
+++ b/tests/release_mode.cpp
@@ -3,7 +3,7 @@
 
 int main ()
 {
-	if constexpr (BuildMode::isRelease && !BuildMode::isDebug)
+	if (BuildMode::isRelease && !BuildMode::isDebug)
 		return EXIT_SUCCESS;
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
Most compiler already optimize by default this simple case:
```cpp
if (true)
{
	// This is compiled in binary
	...
}
if (false)
{
	// This is stripped from binary
	...
}
```

The usage of constexpr-if is not a strict requirement for such simple cases, so by removing it the project requirement can be lower from C++17 to C++11.